### PR TITLE
Switching to single remote user

### DIFF
--- a/build
+++ b/build
@@ -17,7 +17,7 @@ find . -name "*.pyc" -delete
 
 # Run unit tests and calculate code coverage.
 coverage run \
-  --source "$SOURCE_DIR" \
+  --source "$SOURCE_DIR,main.py" \
   -m unittest discover
 
 # Check that source has correct formatting.

--- a/chat_unifier/history_merger.py
+++ b/chat_unifier/history_merger.py
@@ -20,13 +20,12 @@ class Merger(object):
 
 
 def _key_for_history(history):
-    return '%s:%s' % (history.local_username, ','.join(
-        history.remote_usernames))
+    return '%s:%s' % (history.local_username, history.remote_username)
 
 
 def _merge_histories(a, b):
     messages = sorted(a.messages + b.messages, key=lambda m: m.timestamp)
     return models.History(
         local_username=a.local_username,
-        remote_usernames=a.remote_usernames,
+        remote_username=a.remote_username,
         messages=messages)

--- a/chat_unifier/json_serializer.py
+++ b/chat_unifier/json_serializer.py
@@ -24,7 +24,7 @@ def _history_list_to_list_of_dicts(history_list):
 def _history_to_dict(history):
     return {
         'localUsername': history.local_username,
-        'remoteUsernames': history.remote_usernames,
+        'remoteUsername': history.remote_username,
         'messages': _messages_to_list_of_dicts(history.messages)
     }
 

--- a/chat_unifier/models.py
+++ b/chat_unifier/models.py
@@ -4,4 +4,4 @@ Message = collections.namedtuple(
     'Message', field_names=['sender', 'timestamp', 'contents'])
 
 History = collections.namedtuple(
-    'History', field_names=['local_username', 'remote_usernames', 'messages'])
+    'History', field_names=['local_username', 'remote_username', 'messages'])

--- a/chat_unifier/parsers/trillian/parser.py
+++ b/chat_unifier/parsers/trillian/parser.py
@@ -9,13 +9,13 @@ class Parser(object):
     def parse(self, log_contents):
         messages = []
         local_username = None
-        remote_usernames = set()
+        remote_username = None
         lines = [x for x in log_contents.split('\n') if x]
         for line in lines:
             parsed_line = line_parser.parse(line)
             if _is_session_start_line(parsed_line):
                 local_username = parsed_line.local_username
-                remote_usernames.add(parsed_line.remote_username)
+                remote_username = parsed_line.remote_username
             elif _is_message_line(parsed_line):
                 messages.append(
                     models.Message(
@@ -24,7 +24,7 @@ class Parser(object):
                         contents=parsed_line.contents))
         return models.History(
             local_username=local_username,
-            remote_usernames=list(remote_usernames),
+            remote_username=remote_username,
             messages=messages)
 
 

--- a/tests/parsers/trillian/test_parser.py
+++ b/tests/parsers/trillian/test_parser.py
@@ -17,7 +17,7 @@ class ParserTest(unittest.TestCase):
 """.lstrip()),
             models.History(
                 local_username='LocalUser456',
-                remote_usernames=['RemoteBuddy123'],
+                remote_username='RemoteBuddy123',
                 messages=[
                     models.Message(
                         sender=u'RemoteBuddy123',

--- a/tests/test_history_merger.py
+++ b/tests/test_history_merger.py
@@ -12,7 +12,7 @@ class HistoryMergerTest(unittest.TestCase):
         merger.add(
             models.History(
                 local_username='dummy_local123',
-                remote_usernames=['dummy_remote345'],
+                remote_username='dummy_remote345',
                 messages=[
                     models.Message(
                         sender='dummy_remote345',
@@ -26,7 +26,7 @@ class HistoryMergerTest(unittest.TestCase):
         merger.add(
             models.History(
                 local_username='dummy_local123',
-                remote_usernames=['dummy_remote345'],
+                remote_username='dummy_remote345',
                 messages=[
                     models.Message(
                         sender='dummy_remote345',
@@ -44,7 +44,7 @@ class HistoryMergerTest(unittest.TestCase):
             merged_history,
             models.History(
                 local_username='dummy_local123',
-                remote_usernames=['dummy_remote345'],
+                remote_username='dummy_remote345',
                 messages=[
                     models.Message(
                         sender='dummy_remote345',
@@ -69,7 +69,7 @@ class HistoryMergerTest(unittest.TestCase):
         merger.add(
             models.History(
                 local_username='dummy_local123',
-                remote_usernames=['dummy_remote345'],
+                remote_username='dummy_remote345',
                 messages=[
                     models.Message(
                         sender='dummy_remote345',
@@ -83,7 +83,7 @@ class HistoryMergerTest(unittest.TestCase):
         merger.add(
             models.History(
                 local_username='dummy_local123',
-                remote_usernames=['dummy_remote999'],
+                remote_username='dummy_remote999',
                 messages=[
                     models.Message(
                         sender='dummy_remote999',

--- a/tests/test_json_serializer.py
+++ b/tests/test_json_serializer.py
@@ -24,9 +24,7 @@ class HistoryTest(unittest.TestCase):
         "timestamp": "2018-10-18T18:27:05Z"
       }
     ], 
-    "remoteUsernames": [
-      "dummy_remote345"
-    ]
+    "remoteUsername": "dummy_remote345"
   }, 
   {
     "localUsername": "dummy_local123", 
@@ -37,9 +35,7 @@ class HistoryTest(unittest.TestCase):
         "timestamp": "2018-10-20T04:15:43Z"
       }
     ], 
-    "remoteUsernames": [
-      "dummy_remote456"
-    ]
+    "remoteUsername": "dummy_remote456"
   }
 ]
 """.strip(),
@@ -47,7 +43,7 @@ class HistoryTest(unittest.TestCase):
                 [
                     models.History(
                         local_username='dummy_local123',
-                        remote_usernames=['dummy_remote345'],
+                        remote_username='dummy_remote345',
                         messages=[
                             models.Message(
                                 sender='dummy_local123',
@@ -57,7 +53,7 @@ class HistoryTest(unittest.TestCase):
                         ]),
                     models.History(
                         local_username='dummy_local123',
-                        remote_usernames=['dummy_remote456'],
+                        remote_username='dummy_remote456',
                         messages=[
                             models.Message(
                                 sender='dummy_remote456',

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -57,7 +57,7 @@ class HistoryTest(unittest.TestCase):
         self.assertEqual(
             models.History(
                 local_username='dummy_local123',
-                remote_usernames=['dummy_remote345'],
+                remote_username='dummy_remote345',
                 messages=[
                     models.Message(
                         sender='dummy_sender',
@@ -66,7 +66,7 @@ class HistoryTest(unittest.TestCase):
                 ]),
             models.History(
                 local_username='dummy_local123',
-                remote_usernames=['dummy_remote345'],
+                remote_username='dummy_remote345',
                 messages=[
                     models.Message(
                         sender='dummy_sender',


### PR DESCRIPTION
Assuming that there's only one remote user per conversation.

This won't work when we get to multi-user chats, but keeping it simple for now.